### PR TITLE
Add property based testing for BT.singleton, BT.lookup, BT.insert and BT.delete

### DIFF
--- a/test/Tree/TreePropertiesSpec.hs
+++ b/test/Tree/TreePropertiesSpec.hs
@@ -1,0 +1,29 @@
+module Tree.TreePropertiesSpec (spec) where
+
+import Data.Text ()
+import qualified Data.Text as Text
+import qualified Database.Tree.Tree as BT
+import qualified Database.Url.Url as Url
+import Relude
+import Test.Hspec
+import Test.Hspec.QuickCheck
+
+spec :: Spec
+spec = do
+  describe "BT.singleton" $ do
+
+    context "when created" $ do
+      prop "should have only the element it was created with" $
+        \(originString, shortenedString) -> do
+          let origin = Text.pack originString
+              short = Text.pack shortenedString
+              url = Url.Url origin short
+          BT.toList (BT.singleton url) `shouldBe` [(short, url)]
+
+    context "when have its element deleted" $ do
+      prop "should have no elements in it" $
+        \(originString, shortenedString) -> do
+          let origin = Text.pack originString
+              short = Text.pack shortenedString
+              url = Url.Url origin short
+          BT.toList (BT.delete short (BT.singleton url)) `shouldBe` []

--- a/test/Tree/TreePropertiesSpec.hs
+++ b/test/Tree/TreePropertiesSpec.hs
@@ -27,3 +27,24 @@ spec = do
               short = Text.pack shortenedString
               url = Url.Url origin short
           BT.toList (BT.delete short (BT.singleton url)) `shouldBe` []
+
+  describe "BT.insert && BT.delete && BT.lookup" $ do
+      context "when insert element" $ do
+        prop "should have this element from lookup" $
+          \(pairs, originString, shortenedString) -> do
+            let origin = Text.pack originString
+                short = Text.pack shortenedString
+                url = Url.Url origin short
+                newPairs = map (bimap Text.pack Text.pack) pairs
+                urls = map (uncurry Url.Url) newPairs
+                tree = BT.fromList [(Url.short url', url') | url' <- urls]
+            BT.lookup short (BT.insert url tree) `shouldBe` Just url
+
+      context "when deleting element" $ do
+        prop "shouldn't have this element from lookup" $
+          \(pairs, shortenedString) -> do
+            let short = Text.pack shortenedString
+                newPairs = map (bimap Text.pack Text.pack) pairs
+                urls = map (uncurry Url.Url) newPairs
+                tree = BT.fromList [(Url.short url', url') | url' <- urls]
+            BT.lookup short (BT.delete short tree) `shouldBe` Nothing

--- a/url-shortener.cabal
+++ b/url-shortener.cabal
@@ -145,6 +145,7 @@ test-suite db-test
       Server.Handler.UsersSpec
       Server.Handler.Util
       Server.UtilSpec
+      Tree.TreePropertiesSpec
       Paths_url_shortener
   hs-source-dirs:
       test


### PR DESCRIPTION
Inserts and deletes are tested on random url trees